### PR TITLE
Feature/refactor extension prefix

### DIFF
--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -416,11 +416,11 @@ extension WCInteractor: WebSocketDelegate {
     public func didReceive(event: WebSocketEvent, client: WebSocket) {
         switch event {
         case .connected(let headers):
-            WCLog("<== websocketDidConnected:\n\(headers)")
+            WCLog("<== websocketDidConnected: \(headers)")
             stateRelay.accept(.connected)
             onConnect()
         case .disconnected(let reason, let code):
-            WCLog("<== websocketDidDisconnected:\n\(reason) with code: \(code)")
+            WCLog("<== websocketDidDisconnected: \(reason) with code: \(code)")
 
             if code == 4022 {
                 let error = WCError.tooManyMessages(desc: reason)
@@ -433,13 +433,13 @@ extension WCInteractor: WebSocketDelegate {
         case .text(let text):
             onReceiveMessage(text: text)
         case .binary(let data):
-            WCLog("<== websocketDidReceiveData:\n\(data.toHexString())")
+            WCLog("<== websocketDidReceiveData: \(data.toHexString())")
         case .pong:
             WCLog("<== pong")
         case .ping:
             WCLog("==> ping")
         case .error(let error):
-            WCLog("<== websocketDidDisconnected:\nerror:\(error.debugDescription)")
+            WCLog("<== websocketDidDisconnected: error:\(error.debugDescription)")
             reconnect()
         case .viabilityChanged(let bool):
             WCLog("<== websocketViabilityChanged: \(bool)")
@@ -467,7 +467,7 @@ extension WCInteractor: WebSocketDelegate {
                 .subscribe(onCompleted: {
                     WCLog("<== websocketDidReconnected")
                 }, onError: { [weak self] error in
-                    WCLog("<== websocketFailedToReconnect:\nerror:\(error.localizedDescription)")
+                    WCLog("<== websocketFailedToReconnect: error:\(error.localizedDescription)")
                     self?.stateRelay.accept(.disconnected)
                     self?.onDisconnect(error: error)
                 }).disposed(by: bag)

--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -314,6 +314,7 @@ extension WCInteractor {
             let request: JSONRPCRequest<[WCSessionUpdateParam]> = try event.decode(decrypted)
             guard let param = request.params.first else { throw WCError.badJSONRPCRequest }
             if param.approved == false {
+                WCLog("method:\(event) approved false so disconnect it")
                 disconnect()
                 self.onSessionKilled?()
             }


### PR DESCRIPTION
### Story
refactor about the websocket session handle

### What's this PR do?
1. Introduce `Source` in `WCSession` to identify the session's source

 ```
public enum Source: String, Codable {
        case unknown
        case wc
        case cwe
    }
```
2.  The payload parsed from a scanned QRCode can be partly url encoded. More specific, we may get payload with `CWE:` or `CWE%3A`. To handle it, introduce the way to get url decoded payload if need.