### PR TITLE
♻️ refactor `WCLog` and introduce the way to register external logger…

### DIFF
--- a/WalletConnect/WCLog.swift
+++ b/WalletConnect/WCLog.swift
@@ -6,10 +6,93 @@
 
 import Foundation
 
-public func WCLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-    #if DEBUG
-    items.forEach {
-        Swift.print("[WCLOG] \($0)", separator: separator, terminator: terminator)
+public protocol WalletConnectLogger {
+    func debug(_ message: String,
+               file: String,
+               function: String,
+               line: Int)
+
+    func info(_ message: String,
+              file: String,
+              function: String,
+              line: Int)
+
+    func error(_ message: String,
+               file: String,
+               function: String,
+               line: Int)
+}
+
+public class WCLogger {
+    public static let shared = WCLogger()
+    private(set) var logger: WalletConnectLogger = WCInternalLogger()
+
+    public static func register(logger: WalletConnectLogger) {
+        shared.logger = logger
     }
-    #endif
+
+    public static func debug(_ message: String,
+                             _ file: String = #file,
+                             _ function: String = #function,
+                             line: Int = #line) {
+
+        shared.logger.debug("[WCLOG] " + message,
+                            file: file,
+                            function: function,
+                            line: line)
+    }
+
+    public static func info(_ message: String,
+                            _ file: String = #file,
+                            _ function: String = #function,
+                            line: Int = #line) {
+
+        shared.logger.info("[WCLOG] " + message,
+                           file: file,
+                           function: function,
+                           line: line)
+    }
+
+    public static func error(_ message: String,
+                             _ file: String = #file,
+                             _ function: String = #function,
+                             line: Int = #line) {
+
+        shared.logger.error("[WCLOG] " + message,
+                            file: file,
+                            function: function,
+                            line: line)
+    }
+}
+
+class WCInternalLogger: WalletConnectLogger {
+
+    func debug(_ message: String,
+               file: String,
+               function: String,
+               line: Int) {
+        WCLog("[WCLOG] debug " + message)
+    }
+
+    func info(_ message: String,
+              file: String,
+              function: String,
+              line: Int) {
+        WCLog("[WCLOG] info " + message)
+    }
+
+    func error(_ message: String,
+               file: String,
+               function: String,
+               line: Int) {
+        WCLog("[WCLOG] error " + message)
+    }
+
+    func WCLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+        #if DEBUG
+        items.forEach {
+            Swift.print("\($0)", separator: separator, terminator: terminator)
+        }
+        #endif
+    }
 }


### PR DESCRIPTION
Refactor `WCLog` and introduce the way to register external logger to use.

More specifically, it enables the `WalletConnect` module to use the logger from app and save the logs from `WalletConnect` to disk. This may help in debugging without console output info.