### PR TITLE
Start refactoring `WalletConnect`

### DIFF
--- a/WalletConnect/JSONRPC/JSONRPC.swift
+++ b/WalletConnect/JSONRPC/JSONRPC.swift
@@ -27,7 +27,7 @@ public struct JSONRPCRequest<T: Codable>: Codable {
      */
     public let session: JSONRPCSession?
 
-    init(id: Int64, method: String, params: T, session: JSONRPCSession? = nil) {
+    public init(id: Int64, method: String, params: T, session: JSONRPCSession? = nil) {
         self.id = id
         self.method = method
         self.params = params

--- a/WalletConnect/JSONRPC/JSONRPC.swift
+++ b/WalletConnect/JSONRPC/JSONRPC.swift
@@ -14,10 +14,10 @@ struct JSONRPCError: Error, Codable {
 }
 
 public struct JSONRPCRequest<T: Codable>: Codable {
-    let id: Int64
+    public let id: Int64
     let jsonrpc = JSONRPCVersion
     let method: String
-    let params: T
+    public let params: T
     /**
      Session info
      
@@ -25,7 +25,7 @@ public struct JSONRPCRequest<T: Codable>: Codable {
 
      this means if connect with original walletConnect, `self.session` is __ALWASY nil__
      */
-    let session: JSONRPCSession?
+    public let session: JSONRPCSession?
 
     init(id: Int64, method: String, params: T, session: JSONRPCSession? = nil) {
         self.id = id

--- a/WalletConnect/Models/IBC/WCIBCTransaction.swift
+++ b/WalletConnect/Models/IBC/WCIBCTransaction.swift
@@ -11,6 +11,10 @@ import SwiftUI
 
 public struct WCIBCTransaction {
     public let requestParam: RequestParam
+
+    public init(requestParam: RequestParam) {
+        self.requestParam = requestParam
+    }
 }
 
 extension WCIBCTransaction {

--- a/WalletConnect/Models/WCEvent.swift
+++ b/WalletConnect/Models/WCEvent.swift
@@ -33,13 +33,13 @@ public enum WCEvent: String {
 
 extension WCEvent {
 
-    static let eth = Set<WCEvent>([.ethSign, .ethPersonalSign, .ethSignTypeData, .ethSignTransaction, .ethSendTransaction])
-    static let bnb = Set<WCEvent>([.bnbSign, .bnbTransactionConfirm])
-    static let trust = Set<WCEvent>([.trustSignTransacation, .getAccounts])
-    static let dc = Set<WCEvent>([.dc_instantRequest, .dc_sessionRequest,
-                                  .dc_sessionUpdate, .dc_killSession])
+    public static let eth = Set<WCEvent>([.ethSign, .ethPersonalSign, .ethSignTypeData, .ethSignTransaction, .ethSendTransaction])
+    public static let bnb = Set<WCEvent>([.bnbSign, .bnbTransactionConfirm])
+    public static let trust = Set<WCEvent>([.trustSignTransacation, .getAccounts])
+    public static let dc = Set<WCEvent>([.dc_instantRequest, .dc_sessionRequest,
+                                         .dc_sessionUpdate, .dc_killSession])
 
-    func decode<T: Codable>(_ data: Data) throws -> JSONRPCRequest<T> {
+    public func decode<T: Codable>(_ data: Data) throws -> JSONRPCRequest<T> {
         return try JSONDecoder().decode(JSONRPCRequest<T>.self, from: data)
     }
 }

--- a/WalletConnect/SubInteractor/WCBinanceInteractor.swift
+++ b/WalletConnect/SubInteractor/WCBinanceInteractor.swift
@@ -14,7 +14,9 @@ public struct WCBinanceInteractor {
 
     var confirmResolvers: [Int64: Resolver<WCBinanceTxConfirmParam>] = [:]
 
-    mutating func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
+    public init() { }
+
+    public mutating func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
         switch event {
         case .bnbSign:
             if let request: JSONRPCRequest<[WCBinanceTradeOrder]> = try? event.decode(decrypted) {

--- a/WalletConnect/SubInteractor/WCEthereumInteractor.swift
+++ b/WalletConnect/SubInteractor/WCEthereumInteractor.swift
@@ -10,7 +10,8 @@ public typealias EthSignClosure = (_ id: Int64, _ payload: WCEthereumSignPayload
                                    _ session: JSONRPCSession?) -> Void
 public typealias EthTransactionClosure = (_ id: Int64, _ event: WCEvent,
                                           _ transaction: WCEthereumTransaction,
-                                          _ session: JSONRPCSession?) -> Void
+                                          _ session: JSONRPCSession?,
+                                          _ timestamp: UInt64?) -> Void
 
 public struct WCEthereumInteractor {
     public var onSign: EthSignClosure?
@@ -18,7 +19,8 @@ public struct WCEthereumInteractor {
 
     public init() { }
 
-    public func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
+    public func handleEvent(_ event: WCEvent, topic: String,
+                            decrypted: Data, timestamp: UInt64?) throws {
         switch event {
         case .ethSign, .ethPersonalSign:
             let request: JSONRPCRequest<[String]> = try event.decode(decrypted)
@@ -33,7 +35,8 @@ public struct WCEthereumInteractor {
         case .ethSendTransaction, .ethSignTransaction:
             let request: JSONRPCRequest<[WCEthereumTransaction]> = try event.decode(decrypted)
             guard !request.params.isEmpty else { throw WCError.badJSONRPCRequest }
-            onTransaction?(request.id, event, request.params[0], request.session)
+            onTransaction?(request.id, event, request.params[0],
+                           request.session, timestamp)
         default:
             break
         }

--- a/WalletConnect/SubInteractor/WCEthereumInteractor.swift
+++ b/WalletConnect/SubInteractor/WCEthereumInteractor.swift
@@ -16,7 +16,9 @@ public struct WCEthereumInteractor {
     public var onSign: EthSignClosure?
     public var onTransaction: EthTransactionClosure?
 
-    func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
+    public init() { }
+
+    public func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
         switch event {
         case .ethSign, .ethPersonalSign:
             let request: JSONRPCRequest<[String]> = try event.decode(decrypted)

--- a/WalletConnect/SubInteractor/WCIBCInteractor.swift
+++ b/WalletConnect/SubInteractor/WCIBCInteractor.swift
@@ -13,4 +13,6 @@ public typealias IBCTransactionClosure = (_ id: Int64, _ event: WCEvent,
 
 public struct WCIBCInteractor {
     public var onTransaction: IBCTransactionClosure?
+
+    public init() { }
 }

--- a/WalletConnect/SubInteractor/WCIBCInteractor.swift
+++ b/WalletConnect/SubInteractor/WCIBCInteractor.swift
@@ -9,7 +9,8 @@ import Foundation
 
 public typealias IBCTransactionClosure = (_ id: Int64, _ event: WCEvent,
                                           _ transaction: WCIBCTransaction,
-                                          _ session: JSONRPCSession?) -> Void
+                                          _ session: JSONRPCSession?,
+                                          _ timestamp: UInt64?) -> Void
 
 public struct WCIBCInteractor {
     public var onTransaction: IBCTransactionClosure?

--- a/WalletConnect/SubInteractor/WCTrustInteractor.swift
+++ b/WalletConnect/SubInteractor/WCTrustInteractor.swift
@@ -13,7 +13,9 @@ public struct WCTrustInteractor {
     public var onTransactionSign: TransactionSignClosure?
     public var onGetAccounts: GetAccountsClosure?
 
-    func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
+    public init() { }
+
+    public func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws {
         switch event {
         case .trustSignTransacation:
             let request: JSONRPCRequest<[WCTrustTransaction]> = try event.decode(decrypted)

--- a/WalletConnect/WCError.swift
+++ b/WalletConnect/WCError.swift
@@ -11,5 +11,6 @@ public enum WCError: LocalizedError {
     case badJSONRPCRequest
     case sessionInvalid
     case sessionRequestTimeout
+    case security(desc: String)
     case unknown
 }

--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -86,8 +86,8 @@ open class WCInteractor {
         socket.onConnect = { [weak self] in self?.onConnect() }
         socket.onDisconnect = { [weak self] error in self?.onDisconnect(error: error) }
         socket.onText = { [weak self] text in self?.onReceiveMessage(text: text) }
-        socket.onPong = { _ in WCLog("<== pong") }
-        socket.onData = { data in WCLog("<== websocketDidReceiveData: \(data.toHexString())") }
+        socket.onPong = { _ in WCLogger.info("<== pong") }
+        socket.onData = { data in WCLogger.info("<== websocketDidReceiveData: \(data.toHexString())") }
 
         WCLogger.info("interactor init session.topic:\(session.topic) clientId:\(clientId)")
     }

--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -23,7 +23,8 @@ public enum WCInteractorState {
 }
 
 public protocol WCInteractorDelegate: class {
-    func handleEvent(_ event: WCEvent, topic: String, decrypted: Data) throws
+    func handleEvent(_ event: WCEvent, topic: String,
+                     decrypted: Data, timestamp: UInt64?) throws
 }
 
 open class WCInteractor {
@@ -351,7 +352,9 @@ extension WCInteractor {
                 WCLog("<== decrypted: \(String(data: decrypted, encoding: .utf8)!)")
                 if let method = json["method"] as? String {
                     if let event = WCEvent(rawValue: method) {
-                        try delegate?.handleEvent(event, topic: topic, decrypted: decrypted)
+                        try delegate?.handleEvent(event, topic: topic,
+                                                  decrypted: decrypted,
+                                                  timestamp: timestamp)
                     } else if let id = json["id"] as? Int64 {
                         onCustomRequest?(id, json)
                     }

--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -139,28 +139,6 @@ open class WCInteractor {
     }
 
     @discardableResult
-    open func approveSession(accounts: [String],
-                             chainId: String,
-                             selectedWalletId: String? = nil,
-                             wallets: [WCSessionWalletInfo]? = nil) -> Promise<Void> {
-        guard handshakeId > 0 else {
-            return Promise(error: WCError.sessionInvalid)
-        }
-        let result = WCApproveSessionResponse(
-            approved: true,
-            chainId: chainId,
-            accounts: accounts,
-            peerId: clientId,
-            peerMeta: clientMeta,
-            chainType: chainType,
-            selectedWalletId: selectedWalletId,
-            wallets: wallets
-        )
-        let response = JSONRPCResponse(id: handshakeId, result: result)
-        return encryptAndSend(data: response.encoded)
-    }
-
-    @discardableResult
     open func rejectSession(_ message: String = "Session Rejected") -> Promise<Void> {
         guard handshakeId > 0 else {
             return Promise(error: WCError.sessionInvalid)
@@ -179,27 +157,20 @@ open class WCInteractor {
                 self?.disconnect()
             }
     }
-    
-    open func updateSession(chainId: String, accounts: [String],
-                            method: WCEvent,
-                            selectedWalletId: String? = nil,
-                            wallets: [WCSessionWalletInfo]? = nil) -> Promise<Void> {
-        let result = WCSessionUpdateParam(approved: true,
-                                          chainId: chainId,
-                                          accounts: accounts,
-                                          chainType: chainType,
-                                          selectedWalletId: selectedWalletId,
-                                          wallets: wallets)
-        let response = JSONRPCRequest(id: generateId(), method: method.rawValue, params: [result])
-        return encryptAndSend(data: response.encoded)
+
+    @discardableResult
+    open func updateSession<T: Codable>(request: T) -> Promise<Void> {
+        return encryptAndSend(data: request.encoded)
     }
 
     // MARK: - request operations
+    @discardableResult
     open func approveRequest<T: Codable>(id: Int64, result: T) -> Promise<Void> {
         let response = JSONRPCResponse(id: id, result: result)
         return encryptAndSend(data: response.encoded)
     }
 
+    @discardableResult
     open func rejectRequest(id: Int64, message: String) -> Promise<Void> {
         let response = JSONRPCErrorResponse(id: id, error: JSONRPCError(code: -32000, message: message))
         return encryptAndSend(data: response.encoded)

--- a/WalletConnect/WCLog.swift
+++ b/WalletConnect/WCLog.swift
@@ -6,10 +6,93 @@
 
 import Foundation
 
-public func WCLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-    #if DEBUG
-    items.forEach {
-        Swift.print("[WCLOG] \($0)", separator: separator, terminator: terminator)
+public protocol WalletConnectLogger {
+    func debug(_ message: String,
+               file: String,
+               function: String,
+               line: Int)
+
+    func info(_ message: String,
+              file: String,
+              function: String,
+              line: Int)
+
+    func error(_ message: String,
+               file: String,
+               function: String,
+               line: Int)
+}
+
+public class WCLogger {
+    public static let shared = WCLogger()
+    private(set) var logger: WalletConnectLogger = WCInternalLogger()
+
+    public static func register(logger: WalletConnectLogger) {
+        shared.logger = logger
     }
-    #endif
+
+    public static func debug(_ message: String,
+                             _ file: String = #file,
+                             _ function: String = #function,
+                             line: Int = #line) {
+
+        shared.logger.debug("[WCLOG] " + message,
+                            file: file,
+                            function: function,
+                            line: line)
+    }
+
+    public static func info(_ message: String,
+                            _ file: String = #file,
+                            _ function: String = #function,
+                            line: Int = #line) {
+
+        shared.logger.info("[WCLOG] " + message,
+                           file: file,
+                           function: function,
+                           line: line)
+    }
+
+    public static func error(_ message: String,
+                             _ file: String = #file,
+                             _ function: String = #function,
+                             line: Int = #line) {
+
+        shared.logger.error("[WCLOG] " + message,
+                            file: file,
+                            function: function,
+                            line: line)
+    }
+}
+
+class WCInternalLogger: WalletConnectLogger {
+
+    func debug(_ message: String,
+               file: String,
+               function: String,
+               line: Int) {
+        WCLog("[WCLOG] debug " + message)
+    }
+
+    func info(_ message: String,
+              file: String,
+              function: String,
+              line: Int) {
+        WCLog("[WCLOG] info " + message)
+    }
+
+    func error(_ message: String,
+               file: String,
+               function: String,
+               line: Int) {
+        WCLog("[WCLOG] error " + message)
+    }
+
+    func WCLog(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+        #if DEBUG
+        items.forEach {
+            Swift.print("\($0)", separator: separator, terminator: terminator)
+        }
+        #endif
+    }
 }

--- a/WalletConnect/WCSession.swift
+++ b/WalletConnect/WCSession.swift
@@ -8,25 +8,36 @@ import Foundation
 import CryptoSwift
 
 public struct WCSession: Codable, Equatable {
-    public static let deprecatedExtensionVersion = 1.0
+    public let decodedString: String
     public let topic: String
     public let version: String
     public let bridge: URL
     public let key: Data
     public let numericalVersion: Double
+    public let componentDicts: [String : String]
 
     public static func from(string: String) -> WCSession? {
-        guard string .hasPrefix("wc:") else {
+        guard let decodedString = WCSession.urlDecodeIfNeed(string: string) else {
             return nil
         }
 
-        let urlString = string.replacingOccurrences(of: "wc:", with: "wc://")
-        guard let url = URL(string: urlString),
-            let topic = url.user,
-            let version = url.host,
-            let components = NSURLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                return nil
+        let subStrings = decodedString.split(separator: ":")
+
+        var urlString = ""
+
+        subStrings.enumerated().forEach { index, subString in
+            urlString += "\(subString)"
+            if index == 0 {
+                urlString += "://"
+            }
         }
+
+        guard let url = URL(string: urlString),
+              let topic = url.user,
+              let version = url.host,
+              let components = NSURLComponents(url: url, resolvingAgainstBaseURL: false) else {
+                  return nil
+              }
 
         var dicts = [String: String]()
         for query in components.queryItems ?? [] {
@@ -35,13 +46,24 @@ public struct WCSession: Codable, Equatable {
             }
         }
         guard let bridge = dicts["bridge"],
-            let bridgeUrl = URL(string: bridge),
-            let key = dicts["key"] else {
-                return nil
-        }
+              let bridgeUrl = URL(string: bridge),
+              let key = dicts["key"] else {
+                  return nil
+              }
 
-        return WCSession(topic: topic, version: version, bridge: bridgeUrl,
+        return WCSession(decodedString: decodedString, topic: topic,
+                         version: version, bridge: bridgeUrl,
                          key: Data(hex: key),
-                         numericalVersion: Double(version) ?? 1.0)
+                         numericalVersion: Double(version) ?? 1.0,
+                         componentDicts: dicts)
+    }
+
+    // may extract this to external implementation
+    private static func urlDecodeIfNeed(string: String) -> String? {
+        if string.hasPrefix("wc:") || string.hasPrefix("CWE:") {
+            return string
+        } else {
+            return string.removingPercentEncoding
+        }
     }
 }


### PR DESCRIPTION
### Story

Restore and then refactor this sdk to make it holds only basic websocket abilities and extract all business-related code out to external implementation.

---

### What's this PR do?

What did you add or change
1. Keep only basic websocket abilities in sdk, extract business event handling to external implementation with `WCInteractorDelegate`
2. Keep only non-business-related info in `WCSession`, extract business-related values to external implementation

To-dos:
1. Refactor `func approveSession` to make it just receive a built message struct and then encrypt&send directly
2. Continue picking other essential changes into this branch