### PR TITLE
🐛 Fixed the `wc_sessionUpdate` `approved == false` case which kills s…

### DIFF
--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -362,6 +362,7 @@ extension WCInteractor {
             guard let param = request.params.first else { throw WCError.badJSONRPCRequest }
             if param.approved == false {
                 disconnect()
+                onSessionKilled?()
             }
         default:
             if WCEvent.eth.contains(event) {


### PR DESCRIPTION
…ession and notifies external caller to clear session store.