### PR TITLE
♻️ move the tracking data closure call after handle the event

### DIFF
--- a/WalletConnect/WCInteractor.swift
+++ b/WalletConnect/WCInteractor.swift
@@ -337,7 +337,6 @@ extension WCInteractor {
                 }
                 WCLogger.info("<== decrypted: \(String(data: decrypted, encoding: .utf8)!)")
                 if let method = json["method"] as? String {
-                    onReceiveNCWTrackingData?(topic, method)
                     if let event = WCEvent(rawValue: method) {
                         try handleEvent(event, topic: topic,
                                         decrypted: decrypted,
@@ -345,6 +344,7 @@ extension WCInteractor {
                     } else if let id = json["id"] as? Int64 {
                         onCustomRequest?(id, json, timestamp)
                     }
+                    onReceiveNCWTrackingData?(topic, method)
                 }
             } catch let error {
                 onError?(error)


### PR DESCRIPTION
move the tracking data closure call after handling the event.
in this way, the interactor will get the right peerID from session request message.