### PR TITLE
✨ add scheme for jump-back previous DApp after connect

### DIFF
--- a/WalletConnect/Models/WCPeerMeta.swift
+++ b/WalletConnect/Models/WCPeerMeta.swift
@@ -11,11 +11,13 @@ public struct WCPeerMeta: Codable {
     public let url: String
     public let description: String
     public let icons: [String]
+    public let scheme: String?
 
-    public init(name: String, url: String, description: String = "", icons: [String] = []) {
+    public init(name: String, url: String, description: String = "", icons: [String] = [], scheme:String? = nil) {
         self.name = name
         self.url = url
         self.description = description
         self.icons = icons
+        self.scheme = scheme
     }
 }


### PR DESCRIPTION
### Story

The DeFi Wallet doesn't automatically go back to the 3rd party app when the 3rd party app’s connection or singing is complete. The user has no easy way to switch back and needs to manually do this . So according to the current situation, we need to optimize this connection.

Solution:
if App send the `scheme` in `peerMeta` to our app through bridge server , so we can use `scheme` as a deep link to jump back  previous App after connect

<img width="1143" alt="截圖 2022-07-01 18 46 11" src="https://user-images.githubusercontent.com/107109856/176880182-103e44c2-9720-4033-bbcf-ca857e57fbed.png">


---

### What's this PR do?

just add additional info `scheme` in model `PeerMeta`

---

### Screenshots?

Any Visual Proofs?

---

### Any Dependent PR?

Does this rely on backend to be deployed first? if so please provide PR if possible, or description if not

---

### Any impact?

e.g. Card Wallet, Crypto Wallet, Fiat Wallet, Buy Flow, Sell Flow

### PR Check List

- [ ] Added changelog item
- [x] Tested
- [ ] QA Approved
